### PR TITLE
[TSK-281] Changes in file saving and Input Parameter

### DIFF
--- a/app/scraper.py
+++ b/app/scraper.py
@@ -24,7 +24,7 @@ class messageData(BaseModel):
     year: int
     month: Literal['January', 'Febuary', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December']
     day: Literal['01', '02', '03', '04', '05', '06', '07', '08', '09', '10', '11', '12', '13', '14', '15', '16', '17', '18', '19', '20', '21', '22', '23', '24', '25', '26', '27', '28', '29', '30', '31']
-    disaster_type: Literal['Wildfire', 'Other']
+    disaster_type: Literal['Wildfire', 'Climate' 'Other']
 
 #Potential alternate prompting
 # class messageDataAlternate(BaseModel):
@@ -69,7 +69,7 @@ def scrape(
 
         output_data_list: list[KernelPlancksterSourceData] = []
 
-        filter = "forest wildfire"
+        filter = query
         # Enables `response_model`
         client = instructor.from_openai(OpenAI(api_key=openai_api_key))
 

--- a/app/scraper.py
+++ b/app/scraper.py
@@ -24,7 +24,7 @@ class messageData(BaseModel):
     year: int
     month: Literal['January', 'Febuary', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December']
     day: Literal['01', '02', '03', '04', '05', '06', '07', '08', '09', '10', '11', '12', '13', '14', '15', '16', '17', '18', '19', '20', '21', '22', '23', '24', '25', '26', '27', '28', '29', '30', '31']
-    disaster_type: Literal['Wildfire', 'Climate' 'Other']
+    disaster_type: str
 
 #Potential alternate prompting
 # class messageDataAlternate(BaseModel):

--- a/server.py
+++ b/server.py
@@ -1,9 +1,9 @@
 import os
 from dotenv import load_dotenv
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
 from app.sdk.job_manager import BaseJobManager
 from app.sdk.job_router import JobManagerFastAPIRouter
-
 from twitter_api_scraper import scrape
 import logging
 
@@ -17,7 +17,6 @@ logging.basicConfig(
 
 logger = logging.getLogger(__name__)
 
-
 HOST = os.getenv("HOST", "localhost")
 PORT = int(os.getenv("PORT", "8000"))
 MODE = os.getenv("MODE", "production")
@@ -25,11 +24,39 @@ MODE = os.getenv("MODE", "production")
 app = FastAPI()
 app.job_manager = BaseJobManager()  # type: ignore
 
-job_manager_router = JobManagerFastAPIRouter(app, scrape)
+# Define a request model for the API
+class ScrapeRequest(BaseModel):
+    query: str
+    start_date: str
+    end_date: str
 
+@app.post("/scrape/")
+async def perform_scrape(request: ScrapeRequest):
+    try:
+        # Call the scrape function
+        scrape(
+            job_id="1",  # dynamic handling
+            query=request.query,
+            tracer_id="1",  # dynamic handling
+            start_date=request.start_date,
+            end_date=request.end_date,
+            work_dir="./.tmp",
+            kp_auth_token=os.getenv("KP_AUTH_TOKEN", ""),
+            kp_host=os.getenv("KP_HOST", "localhost"),
+            kp_port=int(os.getenv("KP_PORT", "8000")),
+            kp_scheme=os.getenv("KP_SCHEME", "http"),
+            openai_api_key=os.getenv("OPENAI_API_KEY", ""),
+            scraper_api_key=os.getenv("SCRAPER_API_KEY", "")
+        )
+        return {"message": "Scrape initiated successfully."}
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+# Setup the job manager router
+job_manager_router = JobManagerFastAPIRouter(app, scrape)
+app.include_router(job_manager_router, prefix="/jobs")
 
 if __name__ == "__main__":
     import uvicorn
-
     print(f"Starting server on {HOST}:{PORT}")
     uvicorn.run("server:app", host=HOST, port=PORT, reload=True)


### PR DESCRIPTION
- For saving the tweets I have utilized the username which is available from the tweets scraped. Plus I have added uuid incase the username are same and consecutive. For timeframe since we are only getting dates they wont be helpful so I have used local time at which the tweets are scraped to further distinct them after saving.
- In twitter while scraping we could actually use any query and start/end dates while using CLI. 
example:- 
python twitter_api_scraper.py --query "Hurricane" --start_date "2024-01-01" --end_date "2024-01-31".
For running it using server.py, I have added the new POST endpoint for inputing query, start date and end date. 
Now the hardcoded parameters are on the augmentation part where currently its using Wildfire as default even when there is different query. @sk-ram can you take a look on how you can modify augmentation part of code.